### PR TITLE
fix: Edit macOS workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
       - name: Install dependencies
         run: |
           ./macos/bootstrap.sh


### PR DESCRIPTION
Remove set up python step as it's covered by bootstrap.sh