### PR TITLE
fix: Update macOS workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,11 @@ jobs:
         with:
           name: macos-dist
           path: dist/
+      - name: Download macOS ARM dist
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-arm-dist
+          path: dist/
       - name: Download Windows dist
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Add arm64 builds to release section